### PR TITLE
[0.14.1] Fix breaking uncached imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.14.1 - 28/09/21
+
+### Fixed
+
+- Uncached module import with specific children breaking.
+
 ## 0.14.0 - 28/09/21
 
 ### Fixed

--- a/packages/chookscord/package.json
+++ b/packages/chookscord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chookscord",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "The Easiest Discord.JS Framework by far.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,7 +31,7 @@
     "dev": "yarn build --watch"
   },
   "dependencies": {
-    "@chookscord/lib": "^0.14.0",
+    "@chookscord/lib": "^0.14.1",
     "@chookscord/types": "^0.3.0",
     "@swc/core": "^1.2.81",
     "@swc/helpers": "^0.2.13",

--- a/packages/chookscord/src/scripts/dev/modules/commands.ts
+++ b/packages/chookscord/src/scripts/dev/modules/commands.ts
@@ -28,9 +28,11 @@ export async function update(
   const endTimer = createTimer();
   logger?.info(`"${fileName}" updated.`);
 
-  const commandFile = await lib.uncachedImport<ChooksSlashCommand>(filePath);
-  const command = lib.pickDefault(commandFile);
+  logger?.debug(`Importing "${fileName}"...`);
+  const commandData = await lib.uncachedImport<ChooksSlashCommand>(filePath);
+  const command = lib.pickDefault(commandData);
 
+  logger?.debug('Import OK. Validating command...');
   if (isCommandValid(command, logger)) {
     store.set(command.name, command);
     paths[fileName] = command.name;

--- a/packages/chookscord/src/scripts/dev/modules/contexts.ts
+++ b/packages/chookscord/src/scripts/dev/modules/contexts.ts
@@ -28,8 +28,12 @@ export async function update(
   const endTimer = createTimer();
   logger?.info(`"${fileName}" updated.`);
 
-  const command = lib.pickDefault(await lib.uncachedImport<ChooksContextCommand>(filePath));
-  if (isCommandValid(command)) {
+  logger?.debug(`Importing "${fileName}"...`);
+  const commandData = await lib.uncachedImport<ChooksContextCommand>(filePath);
+  const command = lib.pickDefault(commandData);
+
+  logger?.debug('Import OK. Validating command...');
+  if (isCommandValid(command, logger)) {
     store.set(command.name, command);
     paths[filePath] = command.name;
     logger?.success(`Command "${command.name}" loaded. Time took: ${endTimer().toLocaleString()}ms`);

--- a/packages/chookscord/src/scripts/dev/modules/events.ts
+++ b/packages/chookscord/src/scripts/dev/modules/events.ts
@@ -26,11 +26,15 @@ export async function update(
   const fileName = basename(filePath);
   logger?.info(`"${fileName}" updated.`);
 
-  const event = lib.pickDefault(await lib.uncachedImport<Event>(filePath));
+  logger?.debug(`Importing "${fileName}"...`);
+  const eventData = await lib.uncachedImport<Event>(filePath);
+  const event = lib.pickDefault(eventData);
+
+  logger?.debug('Import OK. Validating event...');
   if (isEventValid(event)) {
     store.set(event.name, event);
     paths[filePath] = event.name;
-    logger?.success(`"${event.name}" updated.`);
+    logger?.success(`Event "${event.name}" loaded.`);
   }
 }
 

--- a/packages/chookscord/src/scripts/dev/modules/subcommands.ts
+++ b/packages/chookscord/src/scripts/dev/modules/subcommands.ts
@@ -28,8 +28,12 @@ export async function update(
   const endTimer = utils.createTimer();
   logger?.info(`"${fileName}" updated.`);
 
-  const command = lib.pickDefault(await lib.uncachedImport<ChooksSubCommand>(filePath));
-  if (isCommandValid(command)) {
+  logger?.debug(`Importing "${fileName}"...`);
+  const commandData = await lib.uncachedImport<ChooksSubCommand>(filePath);
+  const command = lib.pickDefault(commandData);
+
+  logger?.debug('Import OK. Validating command...');
+  if (isCommandValid(command, logger)) {
     store.set(command.name, command);
     paths[filePath] = command.name;
     logger?.success(`Command "${command.name}" loaded. Time took: ${endTimer().toLocaleString()}ms`);

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chookscord/lib",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {

--- a/packages/lib/src/utils/import.ts
+++ b/packages/lib/src/utils/import.ts
@@ -5,6 +5,8 @@ export type MaybeDefault<T> = T | { default: T };
 // @Choooks22: Not sure how correct this is exactly, or if it overshoots what it's supposed to do.
 // Maybe someone could come and clean this up later, and maybe add esm support here, idk
 function clearChildren(mod: NodeJS.Module) {
+  if (mod.id.includes('node_modules')) return;
+
   if (mod.children.length) {
     mod.children.forEach(clearChildren);
   }
@@ -28,7 +30,7 @@ export async function uncachedImport<T>(path: string): Promise<T> {
 
   delete require.cache[cacheId];
   removeFromMain(mod);
-  clearChildren(mod);
+  // clearChildren(mod);
 
   return imported;
 }

--- a/sample/javascript/package.json
+++ b/sample/javascript/package.json
@@ -9,6 +9,6 @@
     "register": "chooks register"
   },
   "dependencies": {
-    "chookscord": "^0.13.0"
+    "chookscord": "^0.14.1"
   }
 }

--- a/sample/javascript/yarn.lock
+++ b/sample/javascript/yarn.lock
@@ -2,20 +2,20 @@
 # yarn lockfile v1
 
 
-"@chookscord/lib@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@chookscord/lib/-/lib-0.13.0.tgz#e0b511f35dc08eb78752834059b3112b27700d22"
-  integrity sha512-ocISroD8cKK2K1VjiF6unb1bdvPcZt+UOoCGECQH+FjFkGAXMmKZ2r4aTV3h6AR4LfVyZd1Plp1yStVjYw46Lw==
+"@chookscord/lib@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@chookscord/lib/-/lib-0.14.1.tgz#9eefa5b143f7a50bccf5f9846ba8fe0c3198346e"
+  integrity sha512-bb8sHorGWXcaZPWmqqHf9rkcOzuTHr2QgZekHfW0pkz6XD2/g4cjtREXf05XApmntFHF5r39fWvjTQCav2iwiQ==
   dependencies:
     "@chookscord/validate" "^0.3.2"
     "@types/node-fetch" "^2.5.12"
     chalk "^4.1.2"
     consola "^2.15.3"
 
-"@chookscord/types@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@chookscord/types/-/types-0.2.1.tgz#b6bb473a06ad5bc6e19ce4a55cbb4acc92011ff5"
-  integrity sha512-81NtJtw4ApDQlq5DC/+NiPiMwP1j9zlI85984U2Y25ZtFUn1zW5KY27fw7iXshAndKSPnMCGPSxHRJ2zJTiXsA==
+"@chookscord/types@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@chookscord/types/-/types-0.3.0.tgz#fe1505c483d28b3fca99947772e930dc5b3905ec"
+  integrity sha512-2yEpK/C4I/TqGQ9W/NzwR0KfxjAhnTwbds9PH/igo02PqBFCgIVMfyR2b3HHJiwvu8KuOv1C3eGRQYj9n3QvoQ==
 
 "@chookscord/validate@^0.3.2":
   version "0.3.2"
@@ -234,13 +234,13 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chookscord@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/chookscord/-/chookscord-0.13.0.tgz#532abb0583ac7972ec769ae7f90f2d0feaa70c6f"
-  integrity sha512-R3LIn/6nBc+cOlDWzQSsMxGCNwFxXgXx1TL6DRoJ8XOFYn3q6GVDEz6Y99VXW1TzH0R+2MRGesTOZMiJrsCFvA==
+chookscord@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/chookscord/-/chookscord-0.14.1.tgz#4a1796b5700d66198da4422d69257bdc2e8411b8"
+  integrity sha512-TirO6VrRq2N0JavUZxODkDoDfcsJCwb+id7Dblyr/UYm9Ouh4q6FNCthzYbR2/D6g/xtPhLSp7YKzTp7XWpRtQ==
   dependencies:
-    "@chookscord/lib" "^0.13.0"
-    "@chookscord/types" "^0.2.1"
+    "@chookscord/lib" "^0.14.1"
+    "@chookscord/types" "^0.3.0"
     "@swc/core" "^1.2.81"
     "@swc/helpers" "^0.2.13"
     chokidar "^3.5.2"

--- a/sample/typescript/package.json
+++ b/sample/typescript/package.json
@@ -9,7 +9,7 @@
     "register": "chooks register"
   },
   "dependencies": {
-    "chookscord": "^0.13.0"
+    "chookscord": "^0.14.1"
   },
   "devDependencies": {
     "typescript": "^4.4.2"

--- a/sample/typescript/yarn.lock
+++ b/sample/typescript/yarn.lock
@@ -2,20 +2,20 @@
 # yarn lockfile v1
 
 
-"@chookscord/lib@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@chookscord/lib/-/lib-0.13.0.tgz#e0b511f35dc08eb78752834059b3112b27700d22"
-  integrity sha512-ocISroD8cKK2K1VjiF6unb1bdvPcZt+UOoCGECQH+FjFkGAXMmKZ2r4aTV3h6AR4LfVyZd1Plp1yStVjYw46Lw==
+"@chookscord/lib@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@chookscord/lib/-/lib-0.14.1.tgz#9eefa5b143f7a50bccf5f9846ba8fe0c3198346e"
+  integrity sha512-bb8sHorGWXcaZPWmqqHf9rkcOzuTHr2QgZekHfW0pkz6XD2/g4cjtREXf05XApmntFHF5r39fWvjTQCav2iwiQ==
   dependencies:
     "@chookscord/validate" "^0.3.2"
     "@types/node-fetch" "^2.5.12"
     chalk "^4.1.2"
     consola "^2.15.3"
 
-"@chookscord/types@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@chookscord/types/-/types-0.2.1.tgz#b6bb473a06ad5bc6e19ce4a55cbb4acc92011ff5"
-  integrity sha512-81NtJtw4ApDQlq5DC/+NiPiMwP1j9zlI85984U2Y25ZtFUn1zW5KY27fw7iXshAndKSPnMCGPSxHRJ2zJTiXsA==
+"@chookscord/types@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@chookscord/types/-/types-0.3.0.tgz#fe1505c483d28b3fca99947772e930dc5b3905ec"
+  integrity sha512-2yEpK/C4I/TqGQ9W/NzwR0KfxjAhnTwbds9PH/igo02PqBFCgIVMfyR2b3HHJiwvu8KuOv1C3eGRQYj9n3QvoQ==
 
 "@chookscord/validate@^0.3.2":
   version "0.3.2"
@@ -234,13 +234,13 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chookscord@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/chookscord/-/chookscord-0.13.0.tgz#532abb0583ac7972ec769ae7f90f2d0feaa70c6f"
-  integrity sha512-R3LIn/6nBc+cOlDWzQSsMxGCNwFxXgXx1TL6DRoJ8XOFYn3q6GVDEz6Y99VXW1TzH0R+2MRGesTOZMiJrsCFvA==
+chookscord@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/chookscord/-/chookscord-0.14.1.tgz#4a1796b5700d66198da4422d69257bdc2e8411b8"
+  integrity sha512-TirO6VrRq2N0JavUZxODkDoDfcsJCwb+id7Dblyr/UYm9Ouh4q6FNCthzYbR2/D6g/xtPhLSp7YKzTp7XWpRtQ==
   dependencies:
-    "@chookscord/lib" "^0.13.0"
-    "@chookscord/types" "^0.2.1"
+    "@chookscord/lib" "^0.14.1"
+    "@chookscord/types" "^0.3.0"
     "@swc/core" "^1.2.81"
     "@swc/helpers" "^0.2.13"
     chokidar "^3.5.2"


### PR DESCRIPTION
Temporarily disabled unloading modules' children on uncached import, added few more debug logs in module loaders.