### PR TITLE
bugfix: Fix global cli module resolution

### DIFF
--- a/packages/chooksie/src/fetch.ts
+++ b/packages/chooksie/src/fetch.ts
@@ -1,5 +1,6 @@
-import type { Response, RequestInfo, RequestInit, ControlledAsyncIterable } from 'undici'
-import { fetch as _fetch } from 'undici'
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/consistent-type-imports
+const { fetch: _fetch } = require(process.env.CHOOKSIE_UNDICI_PATH ?? 'undici') as typeof import('undici')
+import type { ControlledAsyncIterable, RequestInfo, RequestInit, Response } from 'undici'
 
 export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 export type FetchParams = [url: RequestInfo, init?: RequestInit]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chookscord/cli",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.4",
   "description": "CLI package for the Chooksie Framework",
   "license": "MIT",
   "preferGlobal": true,

--- a/packages/cli/src/bin/index.js
+++ b/packages/cli/src/bin/index.js
@@ -13,9 +13,11 @@ if (!command) {
     CHOOKSIE_VERSION: require('../../package.json').version,
   }
 
-  // Replaces all env variables
   child.fork(script, {
-    env,
+    env: {
+      ...process.env,
+      ...env, // Inject custom env
+    },
     execArgv: ['--enable-source-maps', '--title=chooksie'],
   })
 } else if (command === 'init') {

--- a/packages/cli/src/bin/index.js
+++ b/packages/cli/src/bin/index.js
@@ -8,6 +8,7 @@ if (!command) {
 
   const env = {
     CHOOKSIE_CLI: '',
+    CHOOKSIE_UNDICI_PATH: require.resolve('undici'),
     NODE_ENV: 'development',
     CHOOKSIE_VERSION: require('../../package.json').version,
   }

--- a/packages/cli/src/internals.ts
+++ b/packages/cli/src/internals.ts
@@ -1,4 +1,4 @@
-import { resolveLocal } from './lib'
+import resolveLocal from './lib/resolve'
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 const internals = resolveLocal<typeof import('chooksie/internals')>('chooksie/internals')

--- a/packages/cli/src/lib/register.ts
+++ b/packages/cli/src/lib/register.ts
@@ -1,6 +1,9 @@
 import type { Logger } from 'chooksie'
-import fetch from 'chooksie/fetch'
 import type { AppCommand } from 'chooksie/internals'
+import resolveLocal from './resolve'
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const { fetch } = resolveLocal<typeof import('chooksie/fetch')>('chooksie/fetch')
 
 interface SuccessResult {
   status: 'OK'


### PR DESCRIPTION
Does some whacky things to resolve packages locally and globally.

### This further locks us into the CJS ecosystem!

Might just remove global CLI functionality to simplify development and ease restrictions.